### PR TITLE
Rename database password environment variables for production

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -82,4 +82,4 @@ production:
   <<: *default
   database: offender-management-allocation-api_production
   username: offender-management-allocation-api
-  password: <%= ENV['OFFENDER-MANAGEMENT-ALLOCATION-API_DATABASE_PASSWORD'] %>
+  password: <%= ENV['DATABASE_PASSWORD'] %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -80,6 +80,6 @@ test:
 #
 production:
   <<: *default
-  database: offender-management-allocation-api_production
-  username: offender-management-allocation-api
+  database: <%= ENV['DATABASE_NAME'] %>
+  username: <%= ENV['DATABASE_USERNAME'] %>
   password: <%= ENV['DATABASE_PASSWORD'] %>


### PR DESCRIPTION
- The rails generated env vars are a little long - shorten these
- Move all production db credentials to env vars