### PR TITLE
Install activerecord-safer_migrations gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ git_source(:github) do |repo| "https://github.com/#{repo}.git" end
 
 ruby '2.5.1'
 
+gem 'activerecord-safer_migrations'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'lograge'
 gem 'logstash-event'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,8 @@ GEM
       activemodel (= 5.2.1)
       activesupport (= 5.2.1)
       arel (>= 9.0)
+    activerecord-safer_migrations (2.0.0)
+      activerecord (>= 4.0)
     activestorage (5.2.1)
       actionpack (= 5.2.1)
       activerecord (= 5.2.1)
@@ -186,6 +188,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-safer_migrations
   bootsnap (>= 1.1.0)
   brakeman
   byebug
@@ -207,4 +210,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.4
+   1.16.6


### PR DESCRIPTION
The gem sets lock timeouts to prevent database migrations from locking
a long time.

Without this the risk is having migrations that lock out db connections
that are serving http traffic.

See Readme of the gem for a more in-depth explanation.