### PR TITLE
Reduce 'revision history' value 

### DIFF
--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app: allocation-api
 spec:
   replicas: 3
-  revisionHistoryLimit: 2
+  revisionHistoryLimit: 1
   minReadySeconds: 10
   strategy:
     rollingUpdate:


### PR DESCRIPTION
Reduce 'revision history' value in deploy script in order to conserve resources