### PR TITLE
Allow CircleCI to unlock secrets using 'unallocated unlock'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,14 @@ references:
   decrypt_secrets: &decrypt_secrets
     run:
       name: Decrypt secrets file
-      command: git-crypt unlock
+      command: |
+        gpg --export-ownertrust > /tmp/ownertrust.txt
+        echo $GPG_KEY_ID:1 >> /tmp/ownertrust.txt
+        gpg --import-ownertrust /tmp/ownertrust.txt
+        gpgconf --kill gpg-agent
+        gpg-agent --daemon --allow-preset-passphrase
+        /usr/libexec/gpg-preset-passphrase --preset --passphrase $GPG_PASSPHRASE $GPG_KEY_KEYGRIP_ID
+        git-crypt unlock
 
   test_container_config: &test_container_config
     docker:


### PR DESCRIPTION
- As part of the work to implement new standards for git crypt all GPG passwords now require a master password to be set on the private key
- CircleCI does not have the ability to use an interactive shell when decrypting secrets (i.e. when executing `git-crypt unlock`) so we need to store the `GPG_PASSPHRASE` in memory

Welcome your feedback on the PR ... Also I appreciate it may not be obvious what the new script is doing. Let me know if you think inline comments are warranted or further documentation elsewhere.