### PR TITLE
Only build and push an image on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,7 @@ jobs:
       - *install_gpg
       - *configure_gpg
       - *decrypt_secrets
-      - deploy: 
+      - deploy:
           name: Deploy to staging
           command: |
             kubectl set image -f deploy/deployment.yaml allocation-api=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1} --local -o yaml \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,6 +213,9 @@ workflows:
             - test
             - security-static-analysis
             - rubocop
+          filters:
+            branches:
+              only: master
       - deploy_staging:
           requires:
             - build_and_push_docker_image


### PR DESCRIPTION
We don't need to do this on every commit that's pushed (when the tests pass) - we only need an image in the ECR repo for builds that we want to be able to deploy to staging/production. This will also speed up build times and free up build containers.