### PR TITLE
[Do not merge] Refactor CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ references:
 
 version: 2
 jobs:
-  install_dependencies_and_set_up_test_db:
+  install_dependencies:
     <<: *defaults
     <<: *test_container_config
     steps:
@@ -81,6 +81,15 @@ jobs:
       - persist_to_workspace:
           root: .
           paths: vendor/bundle
+
+  set_up_test_db:
+    <<: *defaults
+    <<: *test_container_config
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/repo
+      - run: bundle --path vendor/bundle
       - run:
           name: Migrate database
           command: |
@@ -199,16 +208,20 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - install_dependencies_and_set_up_test_db
+      - install_dependencies
+      - set_up_test_db:
+          requires:
+            - install_dependencies
       - test:
           requires:
-            - install_dependencies_and_set_up_test_db
+            - install_dependencies
+            - set_up_test_db
       - security-static-analysis:
           requires:
-            - install_dependencies_and_set_up_test_db
+            - install_dependencies
       - rubocop:
           requires:
-            - install_dependencies_and_set_up_test_db
+            - install_dependencies
       - build_and_push_docker_image:
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ references:
 
 version: 2
 jobs:
-  build:
+  install_dependencies_and_set_up_test_db:
     <<: *defaults
     <<: *test_container_config
     steps:
@@ -199,16 +199,16 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build
+      - install_dependencies_and_set_up_test_db
       - test:
           requires:
-            - build
+            - install_dependencies_and_set_up_test_db
       - security-static-analysis:
           requires:
-            - build
+            - install_dependencies_and_set_up_test_db
       - rubocop:
           requires:
-            - build
+            - install_dependencies_and_set_up_test_db
       - build_and_push_docker_image:
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,9 +147,10 @@ jobs:
     <<: *test_container_config
     steps:
       - checkout
-      - setup_remote_docker
       - attach_workspace:
           at: ~/repo
+      - setup_remote_docker:
+          docker_layer_caching: true
       - *setup_aws_cli
       - run:
           name: Build docker image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,6 @@ references:
       command: |
         sudo apt-get --assume-yes install python3-pip
         sudo pip3 install awscli
-        $(aws ecr get-login --region eu-west-1 --no-include-email)
 
 version: 2
 jobs:
@@ -166,6 +165,8 @@ jobs:
       - run:
           name: Push docker image
           command: |
+            login="$(aws ecr get-login --region eu-west-1 --no-include-email)"
+            ${login}
             docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPONAME}:${CIRCLE_SHA1}"
             docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPONAME}:${CIRCLE_SHA1}"
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
@@ -185,7 +186,6 @@ jobs:
       - run:
           name: Kubectl deployment staging setup
           command: |
-            $(aws ecr get-login --region eu-west-1 --no-include-email)
             setup-kube-auth
             kubectl config use-context staging
       - *install_gpg

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,6 +165,7 @@ jobs:
             fi
           environment:
             GITHUB_TEAM_NAME_SLUG: offender-management
+            REPONAME: offender-management-allocation-api
 
   deploy_staging:
     <<: *deploy_container_config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2
 
-defaults: &defaults
-  working_directory: ~/repo
-
 references:
+  defaults: &defaults
+    working_directory: ~/repo
+
   deploy_container_config: &deploy_container_config
     docker:
       - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,3 @@
-version: 2
-
 references:
   defaults: &defaults
     working_directory: ~/repo
@@ -59,6 +57,7 @@ references:
         sudo pip3 install awscli
         $(aws ecr get-login --region eu-west-1 --no-include-email)
 
+version: 2
 jobs:
   build:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,7 +180,6 @@ jobs:
     <<: *deploy_container_config
     steps:
       - checkout
-      - setup_remote_docker
       - attach_workspace:
           at: ~/repo
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,6 @@ references:
           PG_HOST: 127.0.0.1
           PG_USER: ubuntu
           RACK_ENV: test
-          GITHUB_TEAM_NAME_SLUG: offender-management
       - image: circleci/postgres:10.5-alpine
         environment:
           POSTGRES_USER: ubuntu
@@ -164,6 +163,8 @@ jobs:
               docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPONAME}:latest"
               docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPONAME}:latest"
             fi
+          environment:
+            GITHUB_TEAM_NAME_SLUG: offender-management
 
   deploy_staging:
     <<: *deploy_container_config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ references:
           POSTGRES_PASSWORD: ""
           POSTGRES_DB: offender-management-allocation-api_test
 
-  setup_aws_cli: &setup_aws_cli
+  install_aws_cli: &install_aws_cli
     run:
       name: Setup aws on debian environment
       command: |
@@ -180,7 +180,7 @@ jobs:
           at: ~/repo
       - setup_remote_docker:
           docker_layer_caching: true
-      - *setup_aws_cli
+      - *install_aws_cli
       - *build_docker_image
       - *push_docker_image
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,7 @@ jobs:
             curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
             chmod +x ./cc-test-reporter
       - run:
-          name:  Run tests
+          name: Run tests
           command: |
             ./cc-test-reporter before-build
             bundle exec rake

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,11 +2,12 @@ references:
   defaults: &defaults
     working_directory: ~/repo
 
+  github_team_name_slug: &github_team_name_slug
+    GITHUB_TEAM_NAME_SLUG: offender-management
+
   deploy_container_config: &deploy_container_config
     docker:
       - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
-        environment:
-          GITHUB_TEAM_NAME_SLUG: offender-management
 
   install_gpg: &install_gpg
     run:
@@ -82,7 +83,7 @@ references:
           docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPONAME}:latest"
         fi
       environment:
-        GITHUB_TEAM_NAME_SLUG: offender-management
+        <<: *github_team_name_slug
         REPONAME: offender-management-allocation-api
 
 version: 2
@@ -209,6 +210,8 @@ jobs:
               -f ./deploy/network-policy.yaml \
               -f ./deploy/allocation-api-secrets.yaml \
               -f ./deploy/deployment.yaml
+          environment:
+            <<: *github_team_name_slug
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,35 @@ references:
         sudo apt-get --assume-yes install python3-pip
         sudo pip3 install awscli
 
+  build_docker_image: &build_docker_image
+    run:
+      name: Build allocation-api docker image
+      command: |
+        export BUILD_DATE=$(date -Is) >> $BASH_ENV
+        source $BASH_ENV
+        docker build \
+          --build-arg VERSION_NUMBER=${CIRCLE_BUILD_NUM} \
+          --build-arg COMMIT_ID=${CIRCLE_SHA1} \
+          --build-arg BUILD_DATE=${BUILD_DATE} \
+          --build-arg BUILD_TAG=${CIRCLE_BRANCH} \
+          -t app .
+
+  push_docker_image: &push_docker_image
+    run:
+      name: Push allocation-api docker image
+      command: |
+        login="$(aws ecr get-login --region eu-west-1 --no-include-email)"
+        ${login}
+        docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPONAME}:${CIRCLE_SHA1}"
+        docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPONAME}:${CIRCLE_SHA1}"
+        if [ "${CIRCLE_BRANCH}" == "master" ]; then
+          docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPONAME}:latest"
+          docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPONAME}:latest"
+        fi
+      environment:
+        GITHUB_TEAM_NAME_SLUG: offender-management
+        REPONAME: offender-management-allocation-api
+
 version: 2
 jobs:
   install_dependencies:
@@ -151,31 +180,8 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - *setup_aws_cli
-      - run:
-          name: Build docker image
-          command: |
-            export BUILD_DATE=$(date -Is) >> $BASH_ENV
-            source $BASH_ENV
-            docker build \
-              --build-arg VERSION_NUMBER=${CIRCLE_BUILD_NUM} \
-              --build-arg COMMIT_ID=${CIRCLE_SHA1} \
-              --build-arg BUILD_DATE=${BUILD_DATE} \
-              --build-arg BUILD_TAG=${CIRCLE_BRANCH} \
-              -t app .
-      - run:
-          name: Push docker image
-          command: |
-            login="$(aws ecr get-login --region eu-west-1 --no-include-email)"
-            ${login}
-            docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPONAME}:${CIRCLE_SHA1}"
-            docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPONAME}:${CIRCLE_SHA1}"
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPONAME}:latest"
-              docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPONAME}:latest"
-            fi
-          environment:
-            GITHUB_TEAM_NAME_SLUG: offender-management
-            REPONAME: offender-management-allocation-api
+      - *build_docker_image
+      - *push_docker_image
 
   deploy_staging:
     <<: *deploy_container_config


### PR DESCRIPTION
This is mostly the result of comparing our CircleCI config for allocation manager and API and doing things consistently - I've taken more from allocation manager so this PR is bigger than the [corresponding one there](https://github.com/ministryofjustice/offender-management-allocation-manager/pull/136).

The first two commits mean that we can remove a couple of CircleCI envvars. Some other commits reduce the scope of config to only be provided where it's needed.

I'll rebase out the WiP commit which temporarily puts back the image building on branches before this is merged.

I'd still like to sort out our use of images here - we're using `test_container_config` in a lot of places which don't need the postgres container which it includes - but that can be a separate PR.