### PR TITLE
Annotate deployments with CircleCI build URL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,14 +202,14 @@ jobs:
           name: Deploy to staging
           command: |
             kubectl set image -f deploy/deployment.yaml allocation-api=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1} --local -o yaml \
-            | kubectl apply -f -
-            kubectl apply \
+            | kubectl annotate -f - kubernetes.io/change-cause="$CIRCLE_BUILD_URL" --local -o yaml \
+            | kubectl apply --record=false \
+              -f - \
               -f ./deploy/ingress.yaml \
               -f ./deploy/service.yaml \
               -f ./deploy/service-monitor.yaml \
               -f ./deploy/network-policy.yaml \
               -f ./deploy/allocation-api-secrets.yaml \
-              -f ./deploy/deployment.yaml
           environment:
             <<: *github_team_name_slug
 


### PR DESCRIPTION
This should make it easier to identify which job triggered a particular
deployment so that we can roll back to it if we need to.

Borrowed from https://github.com/ministryofjustice/cla_public/pull/797