### PR TITLE
Update migrations setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,5 +31,3 @@ COPY Gemfile /app/Gemfile
 COPY Gemfile.lock /app/Gemfile.lock
 RUN bundle install --without development test --jobs 2 --retry 3
 COPY . /app
-
-ENTRYPOINT ["./run.sh"]

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         - name: allocation-api
           image: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/offender-management/offender-management-allocation-api:latest
           imagePullPolicy: Always
-          command: ['sh', '-c', "bundle exec puma -p 3000 -C ./config/puma_prod.rb --pidfile /tmp/server.pid"]
+          command: ['sh', '-c', "bundle exec rails db:migrate && bundle exec puma -p 3000 -C ./config/puma_prod.rb --pidfile /tmp/server.pid"]
           ports:
             - containerPort: 3000
           livenessProbe:

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-export RAILS_ENV=production
-  echo "running migrate"
-  bin/rake db:migrate
-  echo "launching app"
-bin/puma -b tcp://0.0.0.0:3000 -d -C config/puma_prod.rb


### PR DESCRIPTION
Following the merging of the initial migration setup PR
(https://github.com/ministryofjustice/offender-management-allocation-api/pull/76)
it was established that there was already an entrypoint set in the
deployment.yaml file, and therefore made sense at this point to add the
db:migration command there.  As we get further into the workflow this
could well need to change, but suits our needs at present.