### PR TITLE
Adds support for generation of swagger docs and ui

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,12 +13,15 @@ gem 'puma', '~> 3.11'
 gem 'prometheus_exporter'
 gem 'rails', '~> 5.2.2'
 gem 'sentry-raven'
+gem 'rswag-api'
+gem 'rswag-ui'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails'
   gem 'rubocop'
   gem 'rubocop-rspec'
+  gem 'rswag-specs'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
     ast (2.4.0)
     bootsnap (1.3.2)
@@ -65,6 +67,8 @@ GEM
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.2)
     json (2.1.0)
+    json-schema (2.8.1)
+      addressable (>= 2.4)
     jwt (2.1.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -99,6 +103,7 @@ GEM
     pg (1.1.4)
     powerpack (0.1.2)
     prometheus_exporter (0.4.2)
+    public_suffix (3.0.3)
     puma (3.12.0)
     rack (2.0.6)
     rack-test (1.1.0)
@@ -151,6 +156,15 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
+    rswag-api (2.0.5)
+      railties (>= 3.1, < 6.0)
+    rswag-specs (2.0.5)
+      activesupport (>= 3.1, < 6.0)
+      json-schema (~> 2.2)
+      railties (>= 3.1, < 6.0)
+    rswag-ui (2.0.5)
+      actionpack (>= 3.1, < 6.0)
+      railties (>= 3.1, < 6.0)
     rubocop (0.63.1)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
@@ -208,6 +222,9 @@ DEPENDENCIES
   puma (~> 3.11)
   rails (~> 5.2.2)
   rspec-rails
+  rswag-api
+  rswag-specs
+  rswag-ui
   rubocop
   rubocop-rspec
   sentry-raven

--- a/config/initializers/rswag-api.rb
+++ b/config/initializers/rswag-api.rb
@@ -1,0 +1,13 @@
+Rswag::Api.configure do |c|
+  # Specify a root folder where Swagger JSON files are located
+  # This is used by the Swagger middleware to serve requests for API descriptions
+  # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
+  # that it's configured to generate files in the same folder
+  c.swagger_root = Rails.root.to_s + '/swagger'
+
+  # Inject a lamda function to alter the returned Swagger prior to serialization
+  # The function will have access to the rack env for the current request
+  # For example, you could leverage this to dynamically assign the "host" property
+  #
+  # c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+end

--- a/config/initializers/rswag-ui.rb
+++ b/config/initializers/rswag-ui.rb
@@ -1,0 +1,11 @@
+Rswag::Ui.configure do |c|
+  # List the Swagger endpoints that you want to be documented through the swagger-ui
+  # The first parameter is the path (absolute or relative to the UI host) to the
+  # corresponding JSON endpoint and the second is a title that will be displayed in
+  # the document selector
+  # NOTE: If you're using rspec-api to expose Swagger files (under swagger_root) as JSON
+  # endpoints, then the list below should correspond to the relative paths for those
+  # endpoints
+
+  c.swagger_endpoint '/api-docs/v1/swagger.json', 'Allocation API Docs'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  mount Rswag::Ui::Engine => '/api-docs'
+  mount Rswag::Api::Engine => '/api-docs'
+
   get('status' => 'status#index')
   get('health' => 'health#index')
 end

--- a/spec/requests/health_spec.rb
+++ b/spec/requests/health_spec.rb
@@ -1,9 +1,16 @@
-require 'rails_helper'
+require 'swagger_helper'
 
 describe 'GET /health', type: :request do
-  it 'returns a plain text status' do
-    get('/health')
+  path '/health' do
+    get 'Gets system health' do
+      tags 'System'
+      produces 'text/plain'
 
-    expect(response.body).to eq('Everything is fine.')
+      response '200', 'Successfully returned the system health' do
+        run_test! do |response|
+          expect(response.body).to include('Everything is fine.')
+        end
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'simplecov'
+
 SimpleCov.minimum_coverage 100
 
 SimpleCov.start 'rails' do
@@ -11,6 +12,10 @@ if ENV['CIRCLE_ARTIFACTS']
 end
 
 RSpec.configure do |config|
+  config.formatter = 'progress'
+  config.formatter = 'Rswag::Specs::SwaggerFormatter'
+  config.order = 'defined'
+
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.configure do |config|
+  config.swagger_root = Rails.root.to_s + '/swagger'
+
+  config.swagger_docs = {
+    'v1/swagger.json' => {
+      swagger: '2.0',
+      info: {
+        title: 'Offender Management Allocation API',
+        version: 'v1'
+      },
+      paths: {}
+    }
+  }
+end

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -1,0 +1,25 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Offender Management Allocation API",
+    "version": "v1"
+  },
+  "paths": {
+    "/health": {
+      "get": {
+        "summary": "Gets system health",
+        "tags": [
+          "System"
+        ],
+        "produces": [
+          "text/plain"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the system health"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces a new dependency 'rswag' which will generate swagger
documentation from the rspec tests.  See spec/requests/health_spec.rb
for an example of usage, and https://github.com/domaindrivendev/rswag
for documentation.

Apart from the setup of rswag the main change here is that the
spec_helper now uses the rswag formatter as well as the default progress
formatter, which will generate the swagger file as the tests are run.

After running the rspec tests you can view the swagger ui at /api-docs