### PR TITLE
Allow tests to be auth'd

### DIFF
--- a/spec/requests/status_spec.rb
+++ b/spec/requests/status_spec.rb
@@ -1,11 +1,37 @@
-require 'rails_helper'
+require 'swagger_helper'
 
 describe 'GET /status', type: :request do
-  it 'returns the status of the database' do
-    get('/status', headers: generate_jwt_token)
-    json = JSON.parse(response.body)
+  path '/status' do
+    get 'Gets database status' do
+      tags 'System'
+      produces 'application/json'
+      security [Bearer: {}]
 
-    expect(json['status']).to eq('ok')
-    expect(json['postgresVersion']).to match(/PostgreSQL/)
+      response '200', 'Successfully returned the database status' do
+        examples 'application/json' => {
+          'status': 'ok',
+          'postgresVersion': 'PostgresSQL 10.0'
+        }
+        schema type: :object,
+               properties: {
+                 status: { type: :string },
+                 postgresVersion: { type: :string }
+               }
+
+        let(:Authorization) { "Bearer #{generate_jwt_token}" }
+
+        run_test! do |response|
+          json = JSON.parse(response.body)
+
+          expect(json['status']).to eq('ok')
+          expect(json['postgresVersion']).to match(/PostgreSQL/)
+        end
+      end
+
+      response '401', 'Was not authenticated to return the database status' do
+        let(:Authorization) { '' }
+        run_test!
+      end
+    end
   end
 end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -10,7 +10,15 @@ RSpec.configure do |config|
         title: 'Offender Management Allocation API',
         version: 'v1'
       },
-      paths: {}
+      paths: {},
+      securityDefinitions: {
+        Bearer: {
+          description: "...",
+          type: :apiKey,
+          name: 'Authorization',
+          in: :header
+        }
+      }
     }
   }
 end

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -20,6 +20,56 @@
           }
         }
       }
+    },
+    "/status": {
+      "get": {
+        "summary": "Gets database status",
+        "tags": [
+          "System"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "security": [
+          {
+            "Bearer": {
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the database status",
+            "examples": {
+              "application/json": {
+                "status": "ok",
+                "postgresVersion": "PostgresSQL 10.0"
+              }
+            },
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "string"
+                },
+                "postgresVersion": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Was not authenticated to return the database status"
+          }
+        }
+      }
+    }
+  },
+  "securityDefinitions": {
+    "Bearer": {
+      "description": "...",
+      "type": "apiKey",
+      "name": "Authorization",
+      "in": "header"
     }
   }
 }


### PR DESCRIPTION
This PR allows rspec tests of the API requests to be auth'd and so we
can test the 200 responses we expect.

Tests can obtain a valid token for testing by adding the following to
the `response` section of the test.

```
let(:Authorization) { "Bearer #{generate_jwt_token}" }
```

To ensure that it fails with a bad token you can just set

```
let(:Authorization) { '' }
```

If you do not set the Authorization value at all, then the tests will
fail with an error. The PR also shows how to provide an example response
and a model.  When we have APIs with more complete models, we can 
generate the schema section from a complete/full response.

As a side-effect of this feature we are also able to authenticate with a
token in the swagger-ui.