### PR TITLE
Run a rubocop check after commit

### DIFF
--- a/config/git-hooks/pre-commit.sh
+++ b/config/git-hooks/pre-commit.sh
@@ -4,6 +4,17 @@
 #    $> cd /path/to/repository
 #    $> ln -s ../../config/git-hooks/pre-commit.sh .git/hooks/pre-commit
 #
+
+################################################################################
+# Check that any changes to be committed do not upset rubocop
+#
+FILES="$(git diff --cached --name-only --diff-filter=AMC | grep "\.rb$" | tr '\n' ' ')"
+bundle exec rubocop ${FILES}
+if [ $? -ne 0 ]; then
+  echo "Rubocop failed! You must appease the linter!"
+  exit 1
+fi
+
 ################################################################################
 # https://github.com/AGWA/git-crypt/issues/45#issuecomment-151985431
 # Pre-commit hook to avoid accidentally adding unencrypted files which are


### PR DESCRIPTION
Stops a commit happening unless the code appeases Rubocop