### PR TITLE
Circle's image requires PGHOST not PG_HOST

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,8 +41,8 @@ references:
       - image: circleci/ruby:2.5.3
         environment:
           RAILS_ENV: test
-          PG_HOST: 127.0.0.1
-          PG_USER: ubuntu
+          PGHOST: 127.0.0.1
+          PGUSER: ubuntu
           RACK_ENV: test
       - image: circleci/postgres:10.5-alpine
         environment:


### PR DESCRIPTION
https://circleci.com/docs/2.0/postgres-config/#example-circleci-configuration-for-a-rails-app-with-structuresql 