### PR TITLE
Add endpoint for getting offender's active allocations

### DIFF
--- a/app/controllers/allocation_controller.rb
+++ b/app/controllers/allocation_controller.rb
@@ -6,6 +6,11 @@ class AllocationController < ApplicationController
     render_ok
   end
 
+  def active
+    allocations = AllocationService.active_allocations(active_allocation_params)
+    render_ok(allocations)
+  end
+
 private
 
   def allocation_params
@@ -13,5 +18,11 @@ private
       :nomis_staff_id, :offender_no, :offender_id, :allocated_at_tier,
       :created_by, :prison, :override_reason, :note, :email
     )
+  end
+
+  def active_allocation_params
+    return params.require(:ids).split(',') if request.method == 'GET'
+
+    params.require(:_json)
   end
 end

--- a/app/controllers/allocation_controller.rb
+++ b/app/controllers/allocation_controller.rb
@@ -21,8 +21,6 @@ private
   end
 
   def active_allocation_params
-    return params.require(:ids).split(',') if request.method == 'GET'
-
     params.require(:_json)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,11 +5,12 @@ class ApplicationController < ActionController::API
     render_error
   end
 
-  def render_ok
+  def render_ok(data = nil)
     render(
       json: {
         'status' => 'ok',
-        'errorMessage' => ''
+        'errorMessage' => '',
+        'data' => data
       }
     )
   end

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -2,5 +2,5 @@ class Allocation < ApplicationRecord
   belongs_to :prison_offender_manager
 
   validates :offender_no, :offender_id, :prison, :allocated_at_tier,
-    :created_by, :active, presence: true
+    :created_by, presence: true
 end

--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -10,4 +10,13 @@ class AllocationService
       }
     end
   end
+
+  def self.active_allocations(offender_ids)
+    Allocation.where(offender_id: offender_ids, active: true).map { |a|
+      [
+        a[:offender_id],
+        a
+      ]
+    }.to_h
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,6 @@ Rails.application.routes.draw do
   get('health' => 'health#index')
 
   post('allocation' => 'allocation#create')
+  get('allocation/active' => 'allocation#active')
+  post('allocation/active' => 'allocation#active')
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,5 @@ Rails.application.routes.draw do
   get('health' => 'health#index')
 
   post('allocation' => 'allocation#create')
-  get('allocation/active' => 'allocation#active')
   post('allocation/active' => 'allocation#active')
 end

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -7,5 +7,4 @@ RSpec.describe Allocation, type: :model do
   it { is_expected.to validate_presence_of(:prison) }
   it { is_expected.to validate_presence_of(:allocated_at_tier) }
   it { is_expected.to validate_presence_of(:created_by) }
-  it { is_expected.to validate_presence_of(:active) }
 end

--- a/spec/requests/active_allocation_spec.rb
+++ b/spec/requests/active_allocation_spec.rb
@@ -1,0 +1,85 @@
+require 'swagger_helper'
+
+describe 'POST /allocation', type: :request do
+  before do
+    staff_one = PrisonOffenderManager.create!(nomis_staff_id: '1', working_pattern: '0.5', status: 'active')
+    staff_two = PrisonOffenderManager.create(nomis_staff_id: '2', working_pattern: '0.5', status: 'active')
+    staff_one.allocations.create!(offender_id: 'AB1234BC', offender_no: '12345', allocated_at_tier: 'B', prison: 'LEI', created_by: 'Frank', nomis_staff_id: '1', active: true)
+    staff_two.allocations.create!(offender_id: 'AB1234DD', offender_no: '12346', allocated_at_tier: 'C', prison: 'LEI', created_by: 'Frank', nomis_staff_id: '2', active: true)
+    staff_two.allocations.create!(offender_id: 'AB1234BC', offender_no: '12345', allocated_at_tier: 'B', prison: 'LEI', created_by: 'Frank', nomis_staff_id: '1', active: false)
+  end
+
+  path '/allocation/active' do
+    get 'Obtains active allocation for provided offender id(s)' do
+      tags 'Allocation'
+      produces 'application/json'
+      security [Bearer: '']
+      parameter name: :ids, in: :query, type: :array, required: :id
+
+      after do |example|
+        # Generate an example for the swagger document if there is a response from
+        # the server that can be parsed as json.
+        if response.body.present?
+          example.metadata[:response][:examples] = { 'application/json' => JSON.parse(response.body, symbolize_names: true) }
+        end
+      end
+
+      response '200', 'Returns active allocations for provided offender ids' do
+        let(:Authorization) { "Bearer #{generate_jwt_token}" }
+        let(:ids) { %w[AB1234BC AB1234DD] }
+
+        run_test! do |response|
+          json = JSON.parse(response.body)
+          expect(json['status']).to eq('ok')
+          expect(json['data']['AB1234BC']['nomis_staff_id']).to eq(1)
+          expect(json['data']['AB1234DD']['nomis_staff_id']).to eq(2)
+        end
+      end
+
+      response '401', 'Must be authenticated to create an allocation' do
+        let(:Authorization) { '' }
+        let(:ids) { %w[AB1234BC AB1234DD] }
+
+        run_test!
+      end
+    end
+
+    post 'Obtains active allocation for provided offender id(s)' do
+      tags 'Allocation'
+      produces 'application/json'
+      consumes 'application/json'
+      security [Bearer: '']
+      parameter name: :ids, in: :body, schema: {
+        type: :array,
+        items: { type: :string, required: true }
+      }
+
+      after do |example|
+        # Generate an example for the swagger document if there is a response from
+        # the server that can be parsed as json.
+        if response.body.present?
+          example.metadata[:response][:examples] = { 'application/json' => JSON.parse(response.body, symbolize_names: true) }
+        end
+      end
+
+      response '200', 'Returns active allocations for provided offender ids' do
+        let(:Authorization) { "Bearer #{generate_jwt_token}" }
+        let(:ids) { %w[AB1234BC AB1234DD] }
+
+        run_test! do |response|
+          json = JSON.parse(response.body)
+
+          expect(json['status']).to eq('ok')
+          expect(json['data']['AB1234BC']['nomis_staff_id']).to eq(1)
+          expect(json['data']['AB1234DD']['nomis_staff_id']).to eq(2)
+        end
+      end
+
+      response '401', 'Must be authenticated to create an allocation' do
+        let(:Authorization) { '' }
+        let(:ids) { %w[AB1234BC AB1234DD] }
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/requests/active_allocation_spec.rb
+++ b/spec/requests/active_allocation_spec.rb
@@ -10,40 +10,6 @@ describe 'POST /allocation', type: :request do
   end
 
   path '/allocation/active' do
-    get 'Obtains active allocation for provided offender id(s)' do
-      tags 'Allocation'
-      produces 'application/json'
-      security [Bearer: '']
-      parameter name: :ids, in: :query, type: :array, required: :id
-
-      after do |example|
-        # Generate an example for the swagger document if there is a response from
-        # the server that can be parsed as json.
-        if response.body.present?
-          example.metadata[:response][:examples] = { 'application/json' => JSON.parse(response.body, symbolize_names: true) }
-        end
-      end
-
-      response '200', 'Returns active allocations for provided offender ids' do
-        let(:Authorization) { "Bearer #{generate_jwt_token}" }
-        let(:ids) { %w[AB1234BC AB1234DD] }
-
-        run_test! do |response|
-          json = JSON.parse(response.body)
-          expect(json['status']).to eq('ok')
-          expect(json['data']['AB1234BC']['nomis_staff_id']).to eq(1)
-          expect(json['data']['AB1234DD']['nomis_staff_id']).to eq(2)
-        end
-      end
-
-      response '401', 'Must be authenticated to create an allocation' do
-        let(:Authorization) { '' }
-        let(:ids) { %w[AB1234BC AB1234DD] }
-
-        run_test!
-      end
-    end
-
     post 'Obtains active allocation for provided offender id(s)' do
       tags 'Allocation'
       produces 'application/json'

--- a/spec/requests/allocation_spec.rb
+++ b/spec/requests/allocation_spec.rb
@@ -1,6 +1,13 @@
 require 'swagger_helper'
 
 describe 'POST /allocation', type: :request do
+  before do
+    staff_one = PrisonOffenderManager.create!(nomis_staff_id: '1', working_pattern: '0.5', status: 'active')
+    PrisonOffenderManager.create(nomis_staff_id: '2', working_pattern: '0.5', status: 'active')
+    PrisonOffenderManager.create(nomis_staff_id: '3', working_pattern: '0.5', status: 'active')
+    staff_one.allocations.create!(offender_id: 'AB1234BC', offender_no: '12345', allocated_at_tier: 'B', prison: 'LEI', created_by: 'Frank', nomis_staff_id: '1', active: true)
+  end
+
   path '/allocation' do
     post 'Creates a new allocation' do
       tags 'Allocation'
@@ -70,8 +77,9 @@ describe 'POST /allocation', type: :request do
           expect(json['status']).to eq('ok')
           expect(json['errorMessage']).to eq('')
 
-          expect(Allocation.count).to eq(1)
-          expect(Allocation.first.offender_id).to eq('A1A')
+          expect(Allocation.count).to eq(2)
+          expect(Allocation.where(offender_id: 'A1A').first).not_to be_nil
+          expect(Allocation.where(offender_id: 'A1A').first.nomis_staff_id).to eq(1)
         end
       end
 

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -5,50 +5,9 @@
     "version": "v1"
   },
   "paths": {
-    "/status": {
+    "/allocation/active": {
       "get": {
-        "summary": "Gets database status",
-        "tags": [
-          "System"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "security": [
-          {
-            "Bearer": ""
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully returned the database status",
-            "examples": {
-              "application/json": {
-                "status": "ok",
-                "postgresVersion": "PostgresSQL 10.0"
-              }
-            },
-            "schema": {
-              "type": "object",
-              "properties": {
-                "status": {
-                  "type": "string"
-                },
-                "postgresVersion": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Was not authenticated to return the database status"
-          }
-        }
-      }
-    },
-    "/poms/id=1&id=2&id=3": {
-      "get": {
-        "summary": "Prisoner Offender Managers by multiple ID",
+        "summary": "Obtains active allocation for provided offender id(s)",
         "tags": [
           "Allocation"
         ],
@@ -60,25 +19,134 @@
             "Bearer": ""
           }
         ],
+        "parameters": [
+          {
+            "name": "ids",
+            "in": "query",
+            "type": "array",
+            "required": "id"
+          }
+        ],
         "responses": {
           "200": {
-            "description": "Gets a list of Prisoner Offender Managers"
+            "description": "Returns active allocations for provided offender ids",
+            "examples": {
+              "application/json": {
+                "status": "ok",
+                "errorMessage": "",
+                "data": {
+                  "AB1234BC": {
+                    "id": 1,
+                    "offender_no": "12345",
+                    "offender_id": "AB1234BC",
+                    "prison": "LEI",
+                    "allocated_at_tier": "B",
+                    "reason": null,
+                    "note": null,
+                    "created_by": "Frank",
+                    "active": true,
+                    "prison_offender_manager_id": 1,
+                    "created_at": "2019-02-04T13:22:39.214Z",
+                    "updated_at": "2019-02-04T13:22:39.214Z",
+                    "nomis_staff_id": 1
+                  },
+                  "AB1234DD": {
+                    "id": 2,
+                    "offender_no": "12346",
+                    "offender_id": "AB1234DD",
+                    "prison": "LEI",
+                    "allocated_at_tier": "C",
+                    "reason": null,
+                    "note": null,
+                    "created_by": "Frank",
+                    "active": true,
+                    "prison_offender_manager_id": 2,
+                    "created_at": "2019-02-04T13:22:39.217Z",
+                    "updated_at": "2019-02-04T13:22:39.217Z",
+                    "nomis_staff_id": 2
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Must be authenticated to create an allocation"
           }
         }
-      }
-    },
-    "/health": {
-      "get": {
-        "summary": "Gets system health",
+      },
+      "post": {
+        "summary": "Obtains active allocation for provided offender id(s)",
         "tags": [
-          "System"
+          "Allocation"
         ],
         "produces": [
-          "text/plain"
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ],
+        "security": [
+          {
+            "Bearer": ""
+          }
+        ],
+        "parameters": [
+          {
+            "name": "ids",
+            "in": "body",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "required": true
+              }
+            }
+          }
         ],
         "responses": {
           "200": {
-            "description": "Successfully returned the system health"
+            "description": "Returns active allocations for provided offender ids",
+            "examples": {
+              "application/json": {
+                "status": "ok",
+                "errorMessage": "",
+                "data": {
+                  "AB1234BC": {
+                    "id": 1,
+                    "offender_no": "12345",
+                    "offender_id": "AB1234BC",
+                    "prison": "LEI",
+                    "allocated_at_tier": "B",
+                    "reason": null,
+                    "note": null,
+                    "created_by": "Frank",
+                    "active": true,
+                    "prison_offender_manager_id": 1,
+                    "created_at": "2019-02-04T13:22:39.367Z",
+                    "updated_at": "2019-02-04T13:22:39.367Z",
+                    "nomis_staff_id": 1
+                  },
+                  "AB1234DD": {
+                    "id": 2,
+                    "offender_no": "12346",
+                    "offender_id": "AB1234DD",
+                    "prison": "LEI",
+                    "allocated_at_tier": "C",
+                    "reason": null,
+                    "note": null,
+                    "created_by": "Frank",
+                    "active": true,
+                    "prison_offender_manager_id": 2,
+                    "created_at": "2019-02-04T13:22:39.369Z",
+                    "updated_at": "2019-02-04T13:22:39.369Z",
+                    "nomis_staff_id": 2
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Must be authenticated to create an allocation"
           }
         }
       }
@@ -147,7 +215,14 @@
         ],
         "responses": {
           "200": {
-            "description": "Generatesap an error with missing data",
+            "description": "Creates a new allocation, deactivating any previous allocations for the offender",
+            "examples": {
+              "application/json": {
+                "status": "ok",
+                "errorMessage": "",
+                "data": null
+              }
+            },
             "schema": {
               "type": "object",
               "properties": {
@@ -158,16 +233,88 @@
                   "type": "string"
                 }
               }
-            },
-            "examples": {
-              "application/json": {
-                "status": "error",
-                "errorMessage": "Invalid request"
-              }
             }
           },
           "401": {
             "description": "Must be authenticated to create an allocation"
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "summary": "Gets system health",
+        "tags": [
+          "System"
+        ],
+        "produces": [
+          "text/plain"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the system health"
+          }
+        }
+      }
+    },
+    "/poms/id=1&id=2&id=3": {
+      "get": {
+        "summary": "Prisoner Offender Managers by multiple ID",
+        "tags": [
+          "Allocation"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "security": [
+          {
+            "Bearer": ""
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Gets a list of Prisoner Offender Managers"
+          }
+        }
+      }
+    },
+    "/status": {
+      "get": {
+        "summary": "Gets database status",
+        "tags": [
+          "System"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "security": [
+          {
+            "Bearer": ""
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the database status",
+            "examples": {
+              "application/json": {
+                "status": "ok",
+                "postgresVersion": "PostgresSQL 10.0"
+              }
+            },
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "string"
+                },
+                "postgresVersion": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Was not authenticated to return the database status"
           }
         }
       }

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -6,74 +6,6 @@
   },
   "paths": {
     "/allocation/active": {
-      "get": {
-        "summary": "Obtains active allocation for provided offender id(s)",
-        "tags": [
-          "Allocation"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "security": [
-          {
-            "Bearer": ""
-          }
-        ],
-        "parameters": [
-          {
-            "name": "ids",
-            "in": "query",
-            "type": "array",
-            "required": "id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Returns active allocations for provided offender ids",
-            "examples": {
-              "application/json": {
-                "status": "ok",
-                "errorMessage": "",
-                "data": {
-                  "AB1234BC": {
-                    "id": 1,
-                    "offender_no": "12345",
-                    "offender_id": "AB1234BC",
-                    "prison": "LEI",
-                    "allocated_at_tier": "B",
-                    "reason": null,
-                    "note": null,
-                    "created_by": "Frank",
-                    "active": true,
-                    "prison_offender_manager_id": 1,
-                    "created_at": "2019-02-04T13:22:39.214Z",
-                    "updated_at": "2019-02-04T13:22:39.214Z",
-                    "nomis_staff_id": 1
-                  },
-                  "AB1234DD": {
-                    "id": 2,
-                    "offender_no": "12346",
-                    "offender_id": "AB1234DD",
-                    "prison": "LEI",
-                    "allocated_at_tier": "C",
-                    "reason": null,
-                    "note": null,
-                    "created_by": "Frank",
-                    "active": true,
-                    "prison_offender_manager_id": 2,
-                    "created_at": "2019-02-04T13:22:39.217Z",
-                    "updated_at": "2019-02-04T13:22:39.217Z",
-                    "nomis_staff_id": 2
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Must be authenticated to create an allocation"
-          }
-        }
-      },
       "post": {
         "summary": "Obtains active allocation for provided offender id(s)",
         "tags": [
@@ -122,8 +54,8 @@
                     "created_by": "Frank",
                     "active": true,
                     "prison_offender_manager_id": 1,
-                    "created_at": "2019-02-04T13:22:39.367Z",
-                    "updated_at": "2019-02-04T13:22:39.367Z",
+                    "created_at": "2019-02-04T14:40:29.069Z",
+                    "updated_at": "2019-02-04T14:40:29.069Z",
                     "nomis_staff_id": 1
                   },
                   "AB1234DD": {
@@ -137,8 +69,8 @@
                     "created_by": "Frank",
                     "active": true,
                     "prison_offender_manager_id": 2,
-                    "created_at": "2019-02-04T13:22:39.369Z",
-                    "updated_at": "2019-02-04T13:22:39.369Z",
+                    "created_at": "2019-02-04T14:40:29.072Z",
+                    "updated_at": "2019-02-04T14:40:29.072Z",
                     "nomis_staff_id": 2
                   }
                 }


### PR DESCRIPTION
We need to be able to determine whether an offender (or a list of
offenders) is allocated or not. This endpoint returns the active
allocation record for the provided offender_id (or list of offender_ids).

The response is the same as usual with the addition of a "data" key.

```
{
  "status": "ok",
  "errorMessage": "",
  "data": {

  }
}
```

the data element contains a hash with the offender_id mapping to the
currently active allocation record (if any) for that offender. If the
offender is not currently allocated, their offender_id will not appear
as a key in the hash.