### PR TITLE
Follow existing convention for returning POMs data

### DIFF
--- a/app/controllers/poms_controller.rb
+++ b/app/controllers/poms_controller.rb
@@ -4,11 +4,8 @@ class PomsController < ApplicationController
   def show
     nomis_staff_ids = params.require(:ids).gsub(/[^\d]/, '').split('')
     response = PrisonOffenderManagerService.get_poms(nomis_staff_ids)
+    data = response.as_json(include: [:allocations])
 
-    render(
-      json: {
-        'poms' => response.as_json(include: [:allocations])
-      }
-    )
+    render_ok(data)
   end
 end

--- a/spec/requests/poms_spec.rb
+++ b/spec/requests/poms_spec.rb
@@ -27,9 +27,9 @@ describe 'GET /poms', type: :request do
 
         run_test! do |response|
           json = JSON.parse(response.body)
-          expect(json['poms'].length).to eq(3)
-          expect(json['poms'].first['allocations'].length).to eq(1)
-          expect(json['poms'].first['allocations'].first).to include(
+          expect(json['data'].length).to eq(3)
+          expect(json['data'].first['allocations'].length).to eq(1)
+          expect(json['data'].first['allocations'].first).to include(
             "id" => 1,
             "offender_no" => "12345",
             "offender_id" => "AB1234BC",

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -5,6 +5,43 @@
     "version": "v1"
   },
   "paths": {
+    "/health": {
+      "get": {
+        "summary": "Gets system health",
+        "tags": [
+          "System"
+        ],
+        "produces": [
+          "text/plain"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the system health"
+          }
+        }
+      }
+    },
+    "/poms/id=1&id=2&id=3": {
+      "get": {
+        "summary": "Prisoner Offender Managers by multiple ID",
+        "tags": [
+          "Allocation"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "security": [
+          {
+            "Bearer": ""
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Gets a list of Prisoner Offender Managers"
+          }
+        }
+      }
+    },
     "/allocation/active": {
       "post": {
         "summary": "Obtains active allocation for provided offender id(s)",
@@ -54,8 +91,8 @@
                     "created_by": "Frank",
                     "active": true,
                     "prison_offender_manager_id": 1,
-                    "created_at": "2019-02-04T14:40:29.069Z",
-                    "updated_at": "2019-02-04T14:40:29.069Z",
+                    "created_at": "2019-02-04T15:07:25.166Z",
+                    "updated_at": "2019-02-04T15:07:25.166Z",
                     "nomis_staff_id": 1
                   },
                   "AB1234DD": {
@@ -69,8 +106,8 @@
                     "created_by": "Frank",
                     "active": true,
                     "prison_offender_manager_id": 2,
-                    "created_at": "2019-02-04T14:40:29.072Z",
-                    "updated_at": "2019-02-04T14:40:29.072Z",
+                    "created_at": "2019-02-04T15:07:25.170Z",
+                    "updated_at": "2019-02-04T15:07:25.170Z",
                     "nomis_staff_id": 2
                   }
                 }
@@ -173,43 +210,6 @@
         }
       }
     },
-    "/health": {
-      "get": {
-        "summary": "Gets system health",
-        "tags": [
-          "System"
-        ],
-        "produces": [
-          "text/plain"
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully returned the system health"
-          }
-        }
-      }
-    },
-    "/poms/id=1&id=2&id=3": {
-      "get": {
-        "summary": "Prisoner Offender Managers by multiple ID",
-        "tags": [
-          "Allocation"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "security": [
-          {
-            "Bearer": ""
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Gets a list of Prisoner Offender Managers"
-          }
-        }
-      }
-    },
     "/status": {
       "get": {
         "summary": "Gets database status",
@@ -225,6 +225,9 @@
           }
         ],
         "responses": {
+          "401": {
+            "description": "Was not authenticated to return the database status"
+          },
           "200": {
             "description": "Successfully returned the database status",
             "examples": {
@@ -244,9 +247,6 @@
                 }
               }
             }
-          },
-          "401": {
-            "description": "Was not authenticated to return the database status"
           }
         }
       }


### PR DESCRIPTION
Follow existing convention when returning POMs i.e

```
render(
      json: {
        'status' => 'ok',
        'errorMessage' => '',
        'data' => data
      }
    )
```