### PR TITLE
Update Allocation Table

### DIFF
--- a/app/controllers/allocation_controller.rb
+++ b/app/controllers/allocation_controller.rb
@@ -15,7 +15,7 @@ private
 
   def allocation_params
     params.require(:allocation).permit(
-      :nomis_staff_id, :offender_no, :offender_id, :allocated_at_tier,
+      :nomis_staff_id, :nomis_offender_id, :nomis_booking_id, :allocated_at_tier,
       :created_by, :prison, :override_reason, :note, :email
     )
   end

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -1,6 +1,6 @@
 class Allocation < ApplicationRecord
   belongs_to :prison_offender_manager
 
-  validates :offender_no, :offender_id, :prison, :allocated_at_tier,
+  validates :nomis_offender_id, :nomis_booking_id, :prison, :allocated_at_tier,
     :created_by, presence: true
 end

--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -1,7 +1,8 @@
 class AllocationService
   def self.create_allocation(params)
     Allocation.transaction do
-      Allocation.where(nomis_offender_id: params[:nomis_offender_id]).update_all(active: false)
+      Allocation.where(nomis_offender_id: params[:nomis_offender_id]).
+        update_all(active: false)
       Allocation.create!(params) { |alloc|
         alloc.prison_offender_manager = PrisonOffenderManagerService.
           get_prison_offender_manager(params[:nomis_staff_id])

--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -1,7 +1,7 @@
 class AllocationService
   def self.create_allocation(params)
     Allocation.transaction do
-      Allocation.where(offender_no: params[:offender_no]).update_all(active: false)
+      Allocation.where(nomis_offender_id: params[:nomis_offender_id]).update_all(active: false)
       Allocation.create!(params) { |alloc|
         alloc.prison_offender_manager = PrisonOffenderManagerService.
           get_prison_offender_manager(params[:nomis_staff_id])
@@ -11,10 +11,10 @@ class AllocationService
     end
   end
 
-  def self.active_allocations(offender_ids)
-    Allocation.where(offender_id: offender_ids, active: true).map { |a|
+  def self.active_allocations(nomis_offender_ids)
+    Allocation.where(nomis_offender_id: nomis_offender_ids, active: true).map { |a|
       [
-        a[:offender_id],
+        a[:nomis_offender_id],
         a
       ]
     }.to_h

--- a/db/migrate/20190205104045_remove_column_offender_id.rb
+++ b/db/migrate/20190205104045_remove_column_offender_id.rb
@@ -1,0 +1,9 @@
+class RemoveColumnOffenderId < ActiveRecord::Migration[5.2]
+  def up
+    remove_column :allocations, :offender_id
+  end
+
+  def down
+    add_column :allocations, :offender_id, :string
+  end
+end

--- a/db/migrate/20190205104220_add_column_nomis_booking_id.rb
+++ b/db/migrate/20190205104220_add_column_nomis_booking_id.rb
@@ -1,0 +1,9 @@
+class AddColumnNomisBookingId < ActiveRecord::Migration[5.2]
+  def up
+    add_column :allocations, :nomis_booking_id, :int
+  end
+
+  def down
+    remove_column :allocations, :nomis_booking_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_04_123001) do
+ActiveRecord::Schema.define(version: 2019_02_05_104220) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "allocations", force: :cascade do |t|
-    t.string "offender_no"
-    t.string "offender_id"
+    t.string "nomis_offender_id"
     t.string "prison"
     t.string "allocated_at_tier"
     t.string "reason"
@@ -28,9 +27,9 @@ ActiveRecord::Schema.define(version: 2019_02_04_123001) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "nomis_staff_id"
+    t.integer "nomis_booking_id"
+    t.index ["nomis_offender_id"], name: "index_allocations_on_nomis_offender_id"
     t.index ["nomis_staff_id"], name: "index_allocations_on_nomis_staff_id"
-    t.index ["offender_id"], name: "index_allocations_on_offender_id"
-    t.index ["offender_no"], name: "index_allocations_on_offender_no"
   end
 
   create_table "prison_offender_managers", force: :cascade do |t|

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe Allocation, type: :model do
   it { is_expected.to belong_to(:prison_offender_manager) }
-  it { is_expected.to validate_presence_of(:offender_no) }
-  it { is_expected.to validate_presence_of(:offender_id) }
+  it { is_expected.to validate_presence_of(:nomis_offender_id) }
+  it { is_expected.to validate_presence_of(:nomis_booking_id) }
   it { is_expected.to validate_presence_of(:prison) }
   it { is_expected.to validate_presence_of(:allocated_at_tier) }
   it { is_expected.to validate_presence_of(:created_by) }

--- a/spec/requests/active_allocation_spec.rb
+++ b/spec/requests/active_allocation_spec.rb
@@ -2,11 +2,35 @@ require 'swagger_helper'
 
 describe 'POST /allocation', type: :request do
   before do
-    staff_one = PrisonOffenderManager.create!(nomis_staff_id: '1', working_pattern: '0.5', status: 'active')
-    staff_two = PrisonOffenderManager.create(nomis_staff_id: '2', working_pattern: '0.5', status: 'active')
-    staff_one.allocations.create!(offender_id: 'AB1234BC', offender_no: '12345', allocated_at_tier: 'B', prison: 'LEI', created_by: 'Frank', nomis_staff_id: '1', active: true)
-    staff_two.allocations.create!(offender_id: 'AB1234DD', offender_no: '12346', allocated_at_tier: 'C', prison: 'LEI', created_by: 'Frank', nomis_staff_id: '2', active: true)
-    staff_two.allocations.create!(offender_id: 'AB1234BC', offender_no: '12345', allocated_at_tier: 'B', prison: 'LEI', created_by: 'Frank', nomis_staff_id: '1', active: false)
+    staff_one = PrisonOffenderManager.create!(nomis_staff_id: 1, working_pattern: 0.5, status: 'active')
+    staff_two = PrisonOffenderManager.create(nomis_staff_id: 2, working_pattern: 0.5, status: 'active')
+    staff_one.allocations.create!(
+      nomis_offender_id: 'AB1234BC',
+      nomis_booking_id: 12345,
+      allocated_at_tier: 'B',
+      prison: 'LEI',
+      created_by: 'Frank',
+      nomis_staff_id: 1,
+      active: true
+    )
+    staff_two.allocations.create!(
+      nomis_offender_id: 'AB1234DD',
+      nomis_booking_id: 12346,
+      allocated_at_tier: 'C',
+      prison: 'LEI',
+      created_by: 'Frank',
+      nomis_staff_id: 2,
+      active: true
+    )
+    staff_two.allocations.create!(
+      nomis_offender_id: 'AB1234BC',
+      nomis_booking_id: 12347,
+      allocated_at_tier: 'B',
+      prison: 'LEI',
+      created_by: 'Frank',
+      nomis_staff_id: 1,
+      active: false
+    )
   end
 
   path '/allocation/active' do

--- a/spec/requests/active_allocation_spec.rb
+++ b/spec/requests/active_allocation_spec.rb
@@ -6,7 +6,7 @@ describe 'POST /allocation', type: :request do
     staff_two = PrisonOffenderManager.create(nomis_staff_id: 2, working_pattern: 0.5, status: 'active')
     staff_one.allocations.create!(
       nomis_offender_id: 'AB1234BC',
-      nomis_booking_id: 12345,
+      nomis_booking_id: 12_345,
       allocated_at_tier: 'B',
       prison: 'LEI',
       created_by: 'Frank',
@@ -15,7 +15,7 @@ describe 'POST /allocation', type: :request do
     )
     staff_two.allocations.create!(
       nomis_offender_id: 'AB1234DD',
-      nomis_booking_id: 12346,
+      nomis_booking_id: 12_346,
       allocated_at_tier: 'C',
       prison: 'LEI',
       created_by: 'Frank',
@@ -24,7 +24,7 @@ describe 'POST /allocation', type: :request do
     )
     staff_two.allocations.create!(
       nomis_offender_id: 'AB1234BC',
-      nomis_booking_id: 12347,
+      nomis_booking_id: 12_347,
       allocated_at_tier: 'B',
       prison: 'LEI',
       created_by: 'Frank',

--- a/spec/requests/allocation_spec.rb
+++ b/spec/requests/allocation_spec.rb
@@ -7,7 +7,7 @@ describe 'POST /allocation', type: :request do
     PrisonOffenderManager.create!(nomis_staff_id: 3, working_pattern: 0.5, status: 'active')
     staff_one.allocations.create!(
       nomis_offender_id: 'AB1234BC',
-      nomis_booking_id: 123456,
+      nomis_booking_id: 123_456,
       allocated_at_tier: 'B',
       prison: 'LEI',
       created_by: 'Frank',
@@ -26,12 +26,12 @@ describe 'POST /allocation', type: :request do
         # Generate an example for the swagger document if there is a response from
         # the server that can be parsed as json.
         if response.body.present?
-          example.metadata[:response][:examples] = {'application/json' => JSON.parse(response.body, symbolize_names: true)}
+          example.metadata[:response][:examples] = { 'application/json' => JSON.parse(response.body, symbolize_names: true) }
         end
       end
 
       response '200', 'Generates an error with missing data' do
-        let(:Authorization) {"Bearer #{ generate_jwt_token }"}
+        let(:Authorization) { "Bearer #{generate_jwt_token}" }
         let(:allocation) { { allocation: { prison_offender_manager_id: '1' } } }
 
         run_test! do |response|
@@ -71,7 +71,7 @@ describe 'POST /allocation', type: :request do
           {
             nomis_staff_id: 1,
             nomis_offender_id: nomis_offender_id,
-            nomis_booking_id: 1153753,
+            nomis_booking_id: 1_153_753,
             prison: 'LEI',
             created_by: 'Fred',
             allocated_at_tier: 'A',
@@ -86,7 +86,6 @@ describe 'POST /allocation', type: :request do
 
           expect(json['status']).to eq('ok')
           expect(json['errorMessage']).to eq('')
-
 
           expect(Allocation.count).to eq(2)
           expect(Allocation.where(nomis_offender_id: nomis_offender_id).first).not_to be_nil

--- a/spec/requests/allocation_spec.rb
+++ b/spec/requests/allocation_spec.rb
@@ -2,10 +2,18 @@ require 'swagger_helper'
 
 describe 'POST /allocation', type: :request do
   before do
-    staff_one = PrisonOffenderManager.create!(nomis_staff_id: '1', working_pattern: '0.5', status: 'active')
-    PrisonOffenderManager.create(nomis_staff_id: '2', working_pattern: '0.5', status: 'active')
-    PrisonOffenderManager.create(nomis_staff_id: '3', working_pattern: '0.5', status: 'active')
-    staff_one.allocations.create!(offender_id: 'AB1234BC', offender_no: '12345', allocated_at_tier: 'B', prison: 'LEI', created_by: 'Frank', nomis_staff_id: '1', active: true)
+    staff_one = PrisonOffenderManager.create!(nomis_staff_id: 1, working_pattern: 0.5, status: 'active')
+    PrisonOffenderManager.create!(nomis_staff_id: 2, working_pattern: 0.5, status: 'active')
+    PrisonOffenderManager.create!(nomis_staff_id: 3, working_pattern: 0.5, status: 'active')
+    staff_one.allocations.create!(
+      nomis_offender_id: 'AB1234BC',
+      nomis_booking_id: 123456,
+      allocated_at_tier: 'B',
+      prison: 'LEI',
+      created_by: 'Frank',
+      nomis_staff_id: 1,
+      active: true
+    )
   end
 
   path '/allocation' do
@@ -18,12 +26,12 @@ describe 'POST /allocation', type: :request do
         # Generate an example for the swagger document if there is a response from
         # the server that can be parsed as json.
         if response.body.present?
-          example.metadata[:response][:examples] = { 'application/json' => JSON.parse(response.body, symbolize_names: true) }
+          example.metadata[:response][:examples] = {'application/json' => JSON.parse(response.body, symbolize_names: true)}
         end
       end
 
-      response '200', 'Generatesap an error with missing data' do
-        let(:Authorization) { "Bearer #{generate_jwt_token}" }
+      response '200', 'Generates an error with missing data' do
+        let(:Authorization) {"Bearer #{ generate_jwt_token }"}
         let(:allocation) { { allocation: { prison_offender_manager_id: '1' } } }
 
         run_test! do |response|
@@ -39,9 +47,9 @@ describe 'POST /allocation', type: :request do
         parameter name: :allocation, in: :body, schema: {
           type: :object,
           properties: {
-            nomis_staff_id: { type: :string },
-            offender_no: { type: :string },
-            offender_id: { type: :string },
+            nomis_staff_id: { type: :integer },
+            nomis_offender_no: { type: :string },
+            nomis_booking_id: { type: :integer },
             allocated_at_tier: { type: :string },
             prison: { type: :string },
             created_by: { type: :string },
@@ -49,7 +57,7 @@ describe 'POST /allocation', type: :request do
             note: { type: :string },
             email: { type: :string }
           },
-          required: %w[nomis_staff_id offender_no offender_id prison note]
+          required: %w[nomis_staff_id nomis_offender_id nomis_booking_id prison note]
         }
         schema type: :object,
                properties: {
@@ -58,11 +66,12 @@ describe 'POST /allocation', type: :request do
                }
 
         let(:Authorization) { "Bearer #{generate_jwt_token}" }
+        let(:nomis_offender_id) { 'G4273GI' }
         let(:allocation) {
           {
-            nomis_staff_id: '1',
-            offender_no: '1',
-            offender_id: 'A1A',
+            nomis_staff_id: 1,
+            nomis_offender_id: nomis_offender_id,
+            nomis_booking_id: 1153753,
             prison: 'LEI',
             created_by: 'Fred',
             allocated_at_tier: 'A',
@@ -71,15 +80,17 @@ describe 'POST /allocation', type: :request do
             email: 'test@example.com'
           }
         }
+
         run_test! do |response|
           json = JSON.parse(response.body)
 
           expect(json['status']).to eq('ok')
           expect(json['errorMessage']).to eq('')
 
+
           expect(Allocation.count).to eq(2)
-          expect(Allocation.where(offender_id: 'A1A').first).not_to be_nil
-          expect(Allocation.where(offender_id: 'A1A').first.nomis_staff_id).to eq(1)
+          expect(Allocation.where(nomis_offender_id: nomis_offender_id).first).not_to be_nil
+          expect(Allocation.where(nomis_offender_id: nomis_offender_id).first.nomis_staff_id).to eq(1)
         end
       end
 

--- a/spec/requests/poms_spec.rb
+++ b/spec/requests/poms_spec.rb
@@ -1,17 +1,22 @@
 require 'swagger_helper'
 
 describe 'GET /poms', type: :request do
+  let(:nomis_offender_id) { 'AB1234BC' }
+  let(:nomis_booking_id) { 1_153_753 }
+  let(:tier) { 'B' }
+  let(:author) { 'Frank' }
+
   before do
-    staff_one = PrisonOffenderManager.create!(nomis_staff_id: '1', working_pattern: '0.5', status: 'active')
-    PrisonOffenderManager.create(nomis_staff_id: '2', working_pattern: '0.5', status: 'active')
-    PrisonOffenderManager.create(nomis_staff_id: '3', working_pattern: '0.5', status: 'active')
+    staff_one = PrisonOffenderManager.create!(nomis_staff_id: 1, working_pattern: '0.5', status: 'active')
+    PrisonOffenderManager.create(nomis_staff_id: 1, working_pattern: '0.5', status: 'active')
+    PrisonOffenderManager.create(nomis_staff_id: 3, working_pattern: '0.5', status: 'active')
     staff_one.allocations.create!(
-      offender_id: 'AB1234BC',
-      offender_no: '12345',
-      allocated_at_tier: 'B',
+      nomis_offender_id: nomis_offender_id,
+      nomis_booking_id: nomis_booking_id,
+      allocated_at_tier: tier,
       prison: 'LEI',
-      created_by: 'Frank',
-      nomis_staff_id: '1',
+      created_by: author,
+      nomis_staff_id: 1,
       active: true
     )
   end
@@ -30,17 +35,17 @@ describe 'GET /poms', type: :request do
           expect(json['data'].length).to eq(3)
           expect(json['data'].first['allocations'].length).to eq(1)
           expect(json['data'].first['allocations'].first).to include(
-            "id" => 1,
-            "offender_no" => "12345",
-            "offender_id" => "AB1234BC",
-            "prison" => "LEI",
-            "allocated_at_tier" => "B",
-            "reason" => nil,
-            "note" => nil,
-            "created_by" => "Frank",
-            "active" => true,
-            "nomis_staff_id" => 1
-          )
+            'id' => 1,
+            'nomis_booking_id' => nomis_booking_id,
+            'nomis_offender_id' => nomis_offender_id,
+            'prison' => 'LEI',
+            'allocated_at_tier' => tier,
+            'reason' => nil,
+            'note' => nil,
+            'created_by' => author,
+            'active' => true,
+            'nomis_staff_id' => 1
+          ) 
         end
       end
     end

--- a/spec/requests/poms_spec.rb
+++ b/spec/requests/poms_spec.rb
@@ -45,7 +45,7 @@ describe 'GET /poms', type: :request do
             'created_by' => author,
             'active' => true,
             'nomis_staff_id' => 1
-          ) 
+          )
         end
       end
     end

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -5,43 +5,6 @@
     "version": "v1"
   },
   "paths": {
-    "/health": {
-      "get": {
-        "summary": "Gets system health",
-        "tags": [
-          "System"
-        ],
-        "produces": [
-          "text/plain"
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully returned the system health"
-          }
-        }
-      }
-    },
-    "/poms/id=1&id=2&id=3": {
-      "get": {
-        "summary": "Prisoner Offender Managers by multiple ID",
-        "tags": [
-          "Allocation"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "security": [
-          {
-            "Bearer": ""
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Gets a list of Prisoner Offender Managers"
-          }
-        }
-      }
-    },
     "/allocation/active": {
       "post": {
         "summary": "Obtains active allocation for provided offender id(s)",
@@ -73,6 +36,9 @@
           }
         ],
         "responses": {
+          "401": {
+            "description": "Must be authenticated to create an allocation"
+          },
           "200": {
             "description": "Returns active allocations for provided offender ids",
             "examples": {
@@ -82,8 +48,7 @@
                 "data": {
                   "AB1234BC": {
                     "id": 1,
-                    "offender_no": "12345",
-                    "offender_id": "AB1234BC",
+                    "nomis_offender_id": "AB1234BC",
                     "prison": "LEI",
                     "allocated_at_tier": "B",
                     "reason": null,
@@ -91,14 +56,14 @@
                     "created_by": "Frank",
                     "active": true,
                     "prison_offender_manager_id": 1,
-                    "created_at": "2019-02-04T15:07:25.166Z",
-                    "updated_at": "2019-02-04T15:07:25.166Z",
-                    "nomis_staff_id": 1
+                    "created_at": "2019-02-06T09:13:39.306Z",
+                    "updated_at": "2019-02-06T09:13:39.306Z",
+                    "nomis_staff_id": 1,
+                    "nomis_booking_id": 12345
                   },
                   "AB1234DD": {
                     "id": 2,
-                    "offender_no": "12346",
-                    "offender_id": "AB1234DD",
+                    "nomis_offender_id": "AB1234DD",
                     "prison": "LEI",
                     "allocated_at_tier": "C",
                     "reason": null,
@@ -106,16 +71,14 @@
                     "created_by": "Frank",
                     "active": true,
                     "prison_offender_manager_id": 2,
-                    "created_at": "2019-02-04T15:07:25.170Z",
-                    "updated_at": "2019-02-04T15:07:25.170Z",
-                    "nomis_staff_id": 2
+                    "created_at": "2019-02-06T09:13:39.310Z",
+                    "updated_at": "2019-02-06T09:13:39.310Z",
+                    "nomis_staff_id": 2,
+                    "nomis_booking_id": 12346
                   }
                 }
               }
             }
-          },
-          "401": {
-            "description": "Must be authenticated to create an allocation"
           }
         }
       }
@@ -145,13 +108,13 @@
               "type": "object",
               "properties": {
                 "nomis_staff_id": {
+                  "type": "integer"
+                },
+                "nomis_offender_no": {
                   "type": "string"
                 },
-                "offender_no": {
-                  "type": "string"
-                },
-                "offender_id": {
-                  "type": "string"
+                "nomis_booking_id": {
+                  "type": "integer"
                 },
                 "allocated_at_tier": {
                   "type": "string"
@@ -174,8 +137,8 @@
               },
               "required": [
                 "nomis_staff_id",
-                "offender_no",
-                "offender_id",
+                "nomis_offender_id",
+                "nomis_booking_id",
                 "prison",
                 "note"
               ]
@@ -183,6 +146,9 @@
           }
         ],
         "responses": {
+          "401": {
+            "description": "Must be authenticated to create an allocation"
+          },
           "200": {
             "description": "Creates a new allocation, deactivating any previous allocations for the offender",
             "examples": {
@@ -203,9 +169,43 @@
                 }
               }
             }
-          },
-          "401": {
-            "description": "Must be authenticated to create an allocation"
+          }
+        }
+      }
+    },
+    "/poms/id=1&id=2&id=3": {
+      "get": {
+        "summary": "Prisoner Offender Managers by multiple ID",
+        "tags": [
+          "Allocation"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "security": [
+          {
+            "Bearer": ""
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Gets a list of Prisoner Offender Managers"
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "summary": "Gets system health",
+        "tags": [
+          "System"
+        ],
+        "produces": [
+          "text/plain"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the system health"
           }
         }
       }

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -36,9 +36,6 @@
           }
         ],
         "responses": {
-          "401": {
-            "description": "Must be authenticated to create an allocation"
-          },
           "200": {
             "description": "Returns active allocations for provided offender ids",
             "examples": {
@@ -56,8 +53,8 @@
                     "created_by": "Frank",
                     "active": true,
                     "prison_offender_manager_id": 1,
-                    "created_at": "2019-02-06T09:13:39.306Z",
-                    "updated_at": "2019-02-06T09:13:39.306Z",
+                    "created_at": "2019-02-06T09:22:18.684Z",
+                    "updated_at": "2019-02-06T09:22:18.684Z",
                     "nomis_staff_id": 1,
                     "nomis_booking_id": 12345
                   },
@@ -71,14 +68,58 @@
                     "created_by": "Frank",
                     "active": true,
                     "prison_offender_manager_id": 2,
-                    "created_at": "2019-02-06T09:13:39.310Z",
-                    "updated_at": "2019-02-06T09:13:39.310Z",
+                    "created_at": "2019-02-06T09:22:18.687Z",
+                    "updated_at": "2019-02-06T09:22:18.687Z",
                     "nomis_staff_id": 2,
                     "nomis_booking_id": 12346
                   }
                 }
               }
             }
+          },
+          "401": {
+            "description": "Must be authenticated to create an allocation"
+          }
+        }
+      }
+    },
+    "/status": {
+      "get": {
+        "summary": "Gets database status",
+        "tags": [
+          "System"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "security": [
+          {
+            "Bearer": ""
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the database status",
+            "examples": {
+              "application/json": {
+                "status": "ok",
+                "postgresVersion": "PostgresSQL 10.0"
+              }
+            },
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "string"
+                },
+                "postgresVersion": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Was not authenticated to return the database status"
           }
         }
       }
@@ -150,14 +191,7 @@
             "description": "Must be authenticated to create an allocation"
           },
           "200": {
-            "description": "Creates a new allocation, deactivating any previous allocations for the offender",
-            "examples": {
-              "application/json": {
-                "status": "ok",
-                "errorMessage": "",
-                "data": null
-              }
-            },
+            "description": "Generates an error with missing data",
             "schema": {
               "type": "object",
               "properties": {
@@ -168,7 +202,30 @@
                   "type": "string"
                 }
               }
+            },
+            "examples": {
+              "application/json": {
+                "status": "error",
+                "errorMessage": "Invalid request",
+                "data": null
+              }
             }
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "summary": "Gets system health",
+        "tags": [
+          "System"
+        ],
+        "produces": [
+          "text/plain"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the system health"
           }
         }
       }
@@ -190,63 +247,6 @@
         "responses": {
           "200": {
             "description": "Gets a list of Prisoner Offender Managers"
-          }
-        }
-      }
-    },
-    "/health": {
-      "get": {
-        "summary": "Gets system health",
-        "tags": [
-          "System"
-        ],
-        "produces": [
-          "text/plain"
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully returned the system health"
-          }
-        }
-      }
-    },
-    "/status": {
-      "get": {
-        "summary": "Gets database status",
-        "tags": [
-          "System"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "security": [
-          {
-            "Bearer": ""
-          }
-        ],
-        "responses": {
-          "401": {
-            "description": "Was not authenticated to return the database status"
-          },
-          "200": {
-            "description": "Successfully returned the database status",
-            "examples": {
-              "application/json": {
-                "status": "ok",
-                "postgresVersion": "PostgresSQL 10.0"
-              }
-            },
-            "schema": {
-              "type": "object",
-              "properties": {
-                "status": {
-                  "type": "string"
-                },
-                "postgresVersion": {
-                  "type": "string"
-                }
-              }
-            }
           }
         }
       }


### PR DESCRIPTION
This PR -

- removes the `offender_no` column from the Allocations table and replaces with `nomis_offender_id` column. This is to prevent duplication and to be explicit about what is being stored.
- adds the `nomis_booking_id` column
- Fix's broken tests as a result of the above changes