### PR TITLE
Update services to allow allocations to work

### DIFF
--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -2,10 +2,10 @@ class AllocationService
   def self.create_allocation(params)
     Allocation.transaction do
       Allocation.where(nomis_offender_id: params[:nomis_offender_id]).
-        update_all(active: false)
+      update_all(active: false)
+      params[:prison_offender_manager] = PrisonOffenderManagerService.
+        get_prison_offender_manager(params[:nomis_staff_id])
       Allocation.create!(params) { |alloc|
-        alloc.prison_offender_manager = PrisonOffenderManagerService.
-          get_prison_offender_manager(params[:nomis_staff_id])
         alloc.active = true
         alloc.save!
       }

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -1,7 +1,7 @@
 class PrisonOffenderManagerService
   def self.get_prison_offender_manager(nomis_staff_id)
     PrisonOffenderManager.find_or_create_by!(nomis_staff_id: nomis_staff_id) { |s|
-      s.working_pattern = s.working_pattern || '0'
+      s.working_pattern = s.working_pattern || 0.0
       s.status = s.status || 'inactive'
     }
   end


### PR DESCRIPTION
Whilst implementing the allocation work flow from within the allocation
manager we found a couple of issues that needed to be fixed for
allocations to work.  Firstly we needed to change the working_pattern to
be an integer rather than a string.  Secondly, we needed to pass in the
nomis_staff_id so had to ensure this was added to the params.